### PR TITLE
divide-environment-settings

### DIFF
--- a/server/manage.py
+++ b/server/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'server.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'server.settings.localhost')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/server/server/settings/base.py
+++ b/server/server/settings/base.py
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 # Quick-start development settings - unsuitable for production

--- a/server/server/settings/base.py
+++ b/server/server/settings/base.py
@@ -15,19 +15,6 @@ import os
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
-
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'c83jpzg11-&cby)65g20yze_6hxz3kw1%1p1czeln&l_x5@jl$'
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-ALLOWED_HOSTS = []
-
-
 # Application definition
 
 INSTALLED_APPS = [

--- a/server/server/settings/localhost.py
+++ b/server/server/settings/localhost.py
@@ -1,0 +1,1 @@
+from .base import *

--- a/server/server/settings/localhost.py
+++ b/server/server/settings/localhost.py
@@ -1,1 +1,9 @@
 from .base import *
+
+SECRET_KEY = 'c83jpzg11-&cby)65g20yze_6hxz3kw1%1p1czeln&l_x5@jl$'
+
+DEBUG = True
+ALLOWED_HOSTS = []
+
+CSRF_COOKIE_SECURE = False
+SESSION_COOKIE_SECURE = False

--- a/server/server/settings/production.py
+++ b/server/server/settings/production.py
@@ -1,0 +1,2 @@
+from .base import *
+

--- a/server/server/settings/production.py
+++ b/server/server/settings/production.py
@@ -1,2 +1,9 @@
 from .base import *
 
+SECRET_KEY = os.environ("SECRET_KEY")
+
+DEBUG = False
+ALLOWED_HOSTS = ["tbd.junk-t.com"]
+
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = True

--- a/server/server/wsgi.py
+++ b/server/server/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'server.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'server.settings.production')
 
 application = get_wsgi_application()


### PR DESCRIPTION
#17 に先だって設定ファイルを環境ごとに分割した。
チェックリストについてはまだ一部しか対応していない。
wsgi.pyについては環境設定ファイルのデフォルトをproductionにしたけど、Dockerとかで`runserver`でなく`uwsgi`などを使用して立ち上げる場合、何も指定しないとproductionになってしまうという要因がある。
これについて「localhostにすべきだ」とかなにかコメントくれたら嬉しいっす。