### PR TITLE
add build option to docker-compose command in readme

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -17,7 +17,8 @@ python manage.py runserver
 If success, you can access via http://localhost:8000.
 
 # How to start in the local environment (Docker)
-Just execute below command. This way assumes Docker has already installed.
+Just execute below command. This way assumes Docker has already installed. 
+If building is not needed, omit `--build` option.
 ```
 cd junk-t
 docker-compose up --detach --build 

--- a/server/README.md
+++ b/server/README.md
@@ -20,7 +20,7 @@ If success, you can access via http://localhost:8000.
 Just execute below command. This way assumes Docker has already installed.
 ```
 cd junk-t
-docker-compose up --detach 
+docker-compose up --detach --build 
 ```
 If success, you can access via http://localhost:8000.
 


### PR DESCRIPTION
docker-composeの手順がビルドされていること前提になってしまっているので修正。
README改善。単純な変更やで〜