### PR TITLE
add django-cors-header for local development

### DIFF
--- a/server/Pipfile
+++ b/server/Pipfile
@@ -8,6 +8,7 @@ django = "*"
 djangorestframework = "*"
 pillow = "*"
 uwsgi = "*"
+django-cors-headers = "*"
 
 [dev-packages]
 

--- a/server/Pipfile.lock
+++ b/server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f4d5a5d502d0d6a0c975a1bbc8de45e0ca5bba3f13837f63795552e90f3f0331"
+            "sha256": "a775b9372705f38d72da39b8f7df5fced96ed17508ba9118107290c02f67f159"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,14 @@
             ],
             "index": "pypi",
             "version": "==2.1.1"
+        },
+        "django-cors-headers": {
+            "hashes": [
+                "sha256:5545009c9b233ea7e70da7dbab7cb1c12afa01279895086f98ec243d7eab46fa",
+                "sha256:c4c2ee97139d18541a1be7d96fe337d1694623816d83f53cb7c00da9b94acae1"
+            ],
+            "index": "pypi",
+            "version": "==2.4.0"
         },
         "djangorestframework": {
             "hashes": [

--- a/server/server/settings/base.py
+++ b/server/server/settings/base.py
@@ -27,6 +27,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [
@@ -37,6 +38,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
 ]
 
 ROOT_URLCONF = 'server.urls'

--- a/server/server/settings/localhost.py
+++ b/server/server/settings/localhost.py
@@ -10,3 +10,6 @@ SESSION_COOKIE_SECURE = False
 
 MEDIA_ROOT = BASE_DIR
 MEDIA_URL = ''
+
+# needed when running client as another server.
+CORS_ORIGIN_ALLOW_ALL = True


### PR DESCRIPTION
ローカル環境ではclientを別サーバで立ち上げるためAPIがCORSに引っかかる。
ローカル環境でのみCORSは緩くして対応。