### PR TITLE
support collectstatic

### DIFF
--- a/.docker/conf/nginx/nginx.conf
+++ b/.docker/conf/nginx/nginx.conf
@@ -7,6 +7,8 @@ events {
 }
 
 http {
+    include       /etc/nginx/mime.types;
+
     upstream django {
         server django:8001;
     }

--- a/.docker/django.dockerfile
+++ b/.docker/django.dockerfile
@@ -10,7 +10,6 @@ USER junk-t
 
 # Make static directory for volume
 RUN mkdir -p /home/junk-t/static
-RUN echo "this is staticfile." >> /home/junk-t/static/test.txt
 
 # Deploy web application
 COPY --chown=junk-t ./server /home/junk-t/server
@@ -20,6 +19,7 @@ WORKDIR /home/junk-t/server
 ENV DJANGO_SETTINGS_MODULE server.settings.localhost
 RUN pipenv install
 RUN pipenv run python manage.py migrate
+RUN pipenv run python manage.py collectstatic
 
 # Start web application
 CMD pipenv run uwsgi uwsgi/uwsgi.ini

--- a/.docker/nginx.dockerfile
+++ b/.docker/nginx.dockerfile
@@ -2,7 +2,7 @@
 FROM nginx:1.15.3
 
 # Pass configuration
-COPY ./.docker/conf/nginx/nginx.conf /etc/nginx/conf.d/junk-t/
+COPY ./.docker/conf/nginx/nginx.conf /etc/nginx/nginx-junk-t.conf
 
 # Start web server
-CMD ["nginx", "-c", "/etc/nginx/conf.d/junk-t/nginx.conf", "-g", "daemon off;"]
+CMD ["nginx", "-c", "/etc/nginx/nginx-junk-t.conf", "-g", "daemon off;"]

--- a/server/server/settings/base.py
+++ b/server/server/settings/base.py
@@ -98,3 +98,4 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = os.path.expanduser("~/static/")


### PR DESCRIPTION
#31 の対応。まだ終わってない。レビューOKになったらレビュア追加します。
restframeworkのjquery回りでエラーログが出ててどうやらバージョンの互換性の問題っぽい。
djangoを2.1から2.0にすれば問題なさそうなのでPipfileの記述方法とかを調査中。

cssが読み込めなかったためnginxのデフォルトのtypesをインクルード。
nginx.confの場所とファイル名を変更。あとでデフォルトの設定を見ながらいろいろ設定を見直す。
staticディレクトリはdocker上ではhome直下のstaticに決定。

ボリュームにstaticファイルがうまく入らない場合は `docker volume rm junk-t_static` をおこなって再度確認おなしゃす。